### PR TITLE
Remove docker tag from jlink post

### DIFF
--- a/content/blog/jlink-to-produce-own-runtime/index.md
+++ b/content/blog/jlink-to-produce-own-runtime/index.md
@@ -5,7 +5,6 @@ author: sxa
 description: How to swap a JRE image for a jlink runtime
 tags:
   - Temurin
-  - Docker
 ---
 
 With the release of the latest LTS version of Temurin we have decided not to ship Java Runtime Environments (JREs) separately from the JDK downloads.


### PR DESCRIPTION
Spotted by @tellison 

Article is not related to `docker` so that tag should be removed

Signed-off-by: Stewart X Addison <sxa@redhat.com>