### PR TITLE
Updates to linux installers blog post

### DIFF
--- a/content/blog/eclipse-temurin-linux-installers-available/index.md
+++ b/content/blog/eclipse-temurin-linux-installers-available/index.md
@@ -19,29 +19,17 @@ e.g temurin-17-jdk or temurin-8-jdk
 
 ## Deb installation on Debian or Ubuntu
 
-You need the codename of your Debian or Ubuntu version. It is usually recorded in `/etc/os-release` and can be extracted on Debian by running:
-
-```bash
-cat /etc/os-release | grep VERSION_CODENAME | cut -d = -f 2
-```
-
-and on Ubuntu by running:
-
-```bash
-cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2
-```
-
 1. Ensure the necessary packages are present:
     ```bash
-    sudo apt-get install -y wget apt-transport-https gnupg
+    apt-get install -y wget apt-transport-https gnupg
     ```
 1. Download the Eclipse Adoptium GPG key:
     ```bash
-    wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
+    wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
     ```
 1. Configure the Eclipse Adoptium apt repository by replacing the values in angle brackets:
     ```bash
-    echo "deb https://packages.adoptium.net/artifactory/deb <codename> main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+    echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
     ```
 1. Install the Temurin version you require:
     ```bash
@@ -49,9 +37,9 @@ cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2
     apt-get install temurin-17-jdk
     ```
 
-## Centos/RHEL/Fedora Instructions
+## CentOS/RHEL/Fedora Instructions
 
-1. Add the RPM repo to `/etc/yum.repos.d/adoptium.repo` making sure to change the Centos version if you are not using Centos 8. RPM’s are also available for RHEL and Fedora. To check the full list of versions supported take a look at https://packages.adoptium.net/ui/repos/tree/General/rpm.
+1. Add the RPM repo to `/etc/yum.repos.d/adoptium.repo` making sure to change the CentOS version if you are not using CentOS 8, and if you are on a 32-bit ARM system, replace `$(uname -m)` with `armv7hl`. RPMs are also available for RHEL and Fedora. To check the full list of versions supported take a look at the list in the tree at https://packages.adoptium.net/ui/repos/tree/General after clicking the "Artifacts" link on the left
     ```bash
     cat <<EOF > /etc/yum.repos.d/adoptium.repo
     [Adoptium]


### PR DESCRIPTION
Changes:
- Use inlined version of the command to get the Debian/Ubuntu codename (should be ok as long as there aren't any versions that do not have VERSION_CODENAME - Ubuntu 16.04 and 21.10 both have it so I suspect it'll be good everywhere)
- Remove explicit `sudo` from Debian/Ubuntu commands - it's inconsistent with the equivalent commands in the RPM examples and typically gets in the way if you're starting from running from a root shell.
- Adjust reference to the link of RPM distributions supported, as the existing link does not take you directly to the right place if you click on it.
- Add reference to the fact that using `uname -m` will give the wrong result on 32-bit arm systems (Alternate option: We could switch the command to `uname -m|sed s/armv7l/armv7hf/` but that looks a little odd...
- Changed capitalisation of Centos -> CentOS

While I haven't added it to this PR, we should consider re-wording the bit about RHEL in particular. The repository has explicit directories for Fedora but not RHEL, and the wording we have doesn't make it clear that you currently should use the CentOS directory on RHEL. (We should probably add explicit RHEL directories to the repository, especially given that the centos/8 that we have will be out of support as of tomorrow)

Signed-off-by: Stewart X Addison <sxa@redhat.com>