### PR TITLE
Actions: auto cancel builds if user pushes another commit

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,6 +2,12 @@ name: Linter
 on:
   pull_request:
     branches: [ main ]
+
+# Cancel existing runs if user makes another push
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  
 jobs:
   linter:
     name: "Check on ${{ matrix.os }}"


### PR DESCRIPTION
Currently, if a user pushes several commits to a PR the CI will try to build each commit. This wastes both time and resources.

This PR adds a task that will cancel any other builds for the same PR.