### PR TITLE
Update older jlink blogs to point to JRE reinstatement blog

### DIFF
--- a/content/blog/jlink-to-produce-own-runtime/index.md
+++ b/content/blog/jlink-to-produce-own-runtime/index.md
@@ -12,6 +12,8 @@ This post will show you how to create your own runtime for Java 17+ which is com
 
 ## Why have you decided to stop shipping JREs?
 
+***NOTE: This paragraph has been superceded since we are now shipping JREs with 17+ again - see https://blog.adoptium.net/2021/12/eclipse-temurin-jres-are-back/ for the details, however we still recommend using jlink to produce your own cut down java runtimes where possible***
+
 While the OpenJDK build process still has support for building a JRE via the
 `legacy-jre` target it is, as the name suggests, legacy functionality.  The
 new LTS version provided us with an opportunity to make a clean break and we

--- a/content/blog/using-jlink-in-dockerfiles/index.md
+++ b/content/blog/using-jlink-in-dockerfiles/index.md
@@ -35,6 +35,8 @@ CMD ["java", "-jar", "/opt/app/japp.jar"]
 
 ## What about JRE base images?
 
+***NOTE: This paragraph has been superceded since we are now shipping JREs with 17+ again including docker images - see https://blog.adoptium.net/2021/12/eclipse-temurin-jres-are-back/ for the details, however we still recommend using jlink to produce your own cut down java runtimes where possible***
+
 The Eclipse Temurin project produces JRE images for version 8. For JDK 11+ it is possible to use `jlink` and produce a custom runtime that works directly with your application:
 
 ```dockerfile


### PR DESCRIPTION
Issue reported by @zdtsw - this adjusts the older blogs which have out of date information suggesting we do not publish JREs for recent java releases. I have not adjusted the original content, but given a message in bold directing people to the superceding information in a subsequent blog.